### PR TITLE
Removed 'assets' from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,5 @@
             "Bolt\\Extension\\Cainc\\ContentRevert\\Tests\\": "tests",
             "Bolt\\Tests\\": "./vendor/bolt/bolt/tests/phpunit/unit"
         }
-    },
-    "extra": {
-        "bolt-assets": "assets"
     }
 }


### PR DESCRIPTION
```
Script Bolt\Composer\ExtensionInstaller::handle handling the post-package-install event terminated with an exception

  [UnexpectedValueException]                                                                                                                                                   
  RecursiveDirectoryIterator::__construct(/home/annejan/projects/some-bolt-project/extensions/vendor/cainc/content-revert/assets): failed to open dir: No such file or directory 
```
